### PR TITLE
bump base version to allow up to ghc 9.6

### DIFF
--- a/qsem.cabal
+++ b/qsem.cabal
@@ -19,7 +19,7 @@ library
     QSem
     QSemN
   build-depends:
-      base >=4.6 && <4.13
+      base >=4.6 && <4.19
     , ghc-prim
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
I've tested (see https://github.com/chris-martin/qsem/commit/136b6c8f098908e689cfabbbc8547f8c0850d889) and indeed it builds with ghc 9.2, 9.4, 9.6.